### PR TITLE
Add Parent and Child components to app

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import {useState} from 'react'
 import './App.css'
 import Home from "./components/Home/Home.jsx";
+import Parent from "./components/Parent/Parent.jsx";
 
 function App() {
   const [count, setCount] = useState(0)
@@ -9,6 +10,7 @@ function App() {
       <>
         <div>
           <Home/>
+          <Parent/>
         </div>
       </>
   )

--- a/src/components/Child/Child.jsx
+++ b/src/components/Child/Child.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+function Child({product}) {
+  console.log('Child component props:', product);
+  return (
+      <div>{product}</div>
+  );
+}
+
+export default Child;

--- a/src/components/Parent/Parent.jsx
+++ b/src/components/Parent/Parent.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Child from "../Child/Child.jsx";
+
+function Parent() {
+
+  const [product, setProduct] = React.useState('Laptop');
+
+  return (
+      <>
+        <div>parent</div>
+        <Child product={product}/>
+      </>
+
+  );
+}
+
+export default Parent;
+// This is a Parent component that can be used to wrap Child components or other content.


### PR DESCRIPTION
Introduced new Parent and Child components. Parent manages a 'product' state and passes it as a prop to Child, which displays it. Updated App.jsx to render the Parent component alongside Home.